### PR TITLE
deps: update concurrent-ruby for dependabot alerts

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: ["main"]
 
+  # Validate pull requests before dependency or content changes are merged
+  pull_request:
+    branches: ["main"]
+
   # Allow manual triggering from the Actions tab
   workflow_dispatch:
 
@@ -54,6 +58,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: github.event_name == 'push'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.1.2)
     colorator (1.1.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     csv (3.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)


### PR DESCRIPTION
## Summary
- Updates `concurrent-ruby` from `1.3.6` to `1.3.7` in `Gemfile.lock`.
- Addresses the open Dependabot alerts for CVE-2026-54904, CVE-2026-54905, and CVE-2026-54906, all of which affect `concurrent-ruby` versions prior to `1.3.7`.
- Adds pull request validation for the Jekyll Pages workflow while keeping deployment restricted to pushes to `main`.

## Validation
- GitHub Actions should run the Jekyll build on this pull request.
- After merge, Dependabot should close the three open alerts once the dependency graph refreshes.

## Security
- No runtime site behavior changes.
- No JavaScript or frontend dependency additions.
- Dependency lockfile update only, plus CI validation coverage.